### PR TITLE
Fix release script sed compatibility

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -32,8 +32,9 @@ versioned=(
     "${base}/src/gitted/__init__.py"
     "${base}/sub-scripts/intro.sh"
 )
+SED=$(command -v gsed || command -v sed)
 for f in "${versioned[@]}"; do
-    gsed -i "s/0\.0\.0/${tag}/g" "${f}"
+    "${SED}" -i "s/0\.0\.0/${tag}/g" "${f}"
     git add "${f}"
 done
 if [ -n "${token}" ]; then


### PR DESCRIPTION
## Summary
- fallback to whichever sed implementation is available

## Testing
- `make`
- `bashate -i E006 $(find . -path ./.venv -prune -o \( -name '*.sh' -o -path './scripts/**' \) -type f -print)`

------
https://chatgpt.com/codex/tasks/task_e_688c908fac8c8326aaa0450ae299cb3d